### PR TITLE
readme: update ROSin img links

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,14 @@ Developed in collaboration between:
 -->
 
 <a href="http://rosin-project.eu">
-  <img src="http://rosin-project.eu/wp-content/uploads/rosin_ack_logo_wide.png"
+  <img src="https://raw.githubusercontent.com/rosin-project/press_kit/master/img/rosin_ack_logo_wide.png"
        alt="rosin_logo" height="60" >
 </a>
 
 Supported by ROSIN - ROS-Industrial Quality-Assured Robot Software Components.
 More information: <a href="http://rosin-project.eu">rosin-project.eu</a>
 
-<img src="http://rosin-project.eu/wp-content/uploads/rosin_eu_flag.jpg"
+<img src="https://raw.githubusercontent.com/rosin-project/press_kit/master/img/rosin_eu_flag.jpg"
      alt="eu_flag" height="45" align="left" >
 
 This project has received funding from the European Union’s Horizon 2020


### PR DESCRIPTION
The project page is online, but the images are still available in the press-kit repo.

Similar to https://github.com/UniversalRobots/Universal_Robots_ExternalControl_URCap/pull/35